### PR TITLE
:rocket: Replace 404 on server entrypoint

### DIFF
--- a/build_week/rooms/views.py
+++ b/build_week/rooms/views.py
@@ -1,6 +1,10 @@
 from django.http import JsonResponse
 
 
+def index(request):
+    return JsonResponse({"message": "API entrypoint.  API is stable and operating.  Please consult repository documentation for specifics on the consumption of this API.", "repository_url": "https://github.com/cs19-build-week-1/backend"})
+
+
 def all_rooms(request):
     return JsonResponse([
 

--- a/build_week/urls.py
+++ b/build_week/urls.py
@@ -6,6 +6,7 @@ from rooms import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('auth/', include('users.urls', namespace='users')),
-    path('api/rooms/', views.all_rooms)
+    path('api/rooms/', views.all_rooms),
+    path('', views.index)
 
 ]


### PR DESCRIPTION
Replacing the 404 not found with a standard message and directive to documentation and backend repository.

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update - index route update on server root.
* **What is the current behavior?** (You can also link to an open issue here)
404 page at root path.
- **What is the new behavior (if this is a feature change)?**
A JSON that contains a pleasant message and repository reference are now returned to the client.
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaks, no special changes or modifications otherwise.