### PR TITLE
Feat/authed endpoints

### DIFF
--- a/build_week/rooms/views.py
+++ b/build_week/rooms/views.py
@@ -4,9 +4,9 @@ from rest_framework.permissions import IsAuthenticated
 
 
 class RoomsView(APIView):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = [IsAuthenticated]
 
-    def all_rooms(request):
+    def get(self, request):
         return JsonResponse([
 
             [

--- a/build_week/rooms/views.py
+++ b/build_week/rooms/views.py
@@ -1,32 +1,37 @@
 from django.http import JsonResponse
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
 
 
-def all_rooms(request):
-    return JsonResponse([
+class RoomsView(APIView):
+    permission_classes = (IsAuthenticated,)
 
-        [
-            {"n": 0, "e": 0, "s": 1, "w": 0},
-            {"n": 0, "e": 1, "s": 0, "w": 0},
-            {"n": 0, "e": 0, "s": 1, "w": 1},
-            {"n": 0, "e": 0, "s": 0, "w": 0}
+    def all_rooms(request):
+        return JsonResponse([
 
-        ],
-        [
-            {"n": 1, "e": 1, "s": 0, "w": 0},
-            {"n": 0, "e": 0, "s": 1, "w": 1},
-            {"n": 1, "e": 1, "s": 0, "w": 0},
-            {"n": 0, "e": 0, "s": 0, "w": 1}],
-        [
-            {"n": 0, "e": 0, "s": 1, "w": 0},
-            {"n": 1, "e": 0, "s": 1, "w": 0},
-            {"n": 0, "e": 0, "s": 0, "w": 0},
-            {"n": 0, "e": 0, "s": 0, "w": 0}
-        ],
-        [
-            {"n": 1, "e": 1, "s": 0, "w": 0},
-            {"n": 1, "e": 0, "s": 0, "w": 1},
-            {"n": 0, "e": 1, "s": 1, "w": 0},
-            {"n": 0, "e": 0, "s": 0, "w": 1}
-        ]
-    ], safe=False
-    )
+            [
+                {"n": 0, "e": 0, "s": 1, "w": 0},
+                {"n": 0, "e": 1, "s": 0, "w": 0},
+                {"n": 0, "e": 0, "s": 1, "w": 1},
+                {"n": 0, "e": 0, "s": 0, "w": 0}
+
+            ],
+            [
+                {"n": 1, "e": 1, "s": 0, "w": 0},
+                {"n": 0, "e": 0, "s": 1, "w": 1},
+                {"n": 1, "e": 1, "s": 0, "w": 0},
+                {"n": 0, "e": 0, "s": 0, "w": 1}],
+            [
+                {"n": 0, "e": 0, "s": 1, "w": 0},
+                {"n": 1, "e": 0, "s": 1, "w": 0},
+                {"n": 0, "e": 0, "s": 0, "w": 0},
+                {"n": 0, "e": 0, "s": 0, "w": 0}
+            ],
+            [
+                {"n": 1, "e": 1, "s": 0, "w": 0},
+                {"n": 1, "e": 0, "s": 0, "w": 1},
+                {"n": 0, "e": 1, "s": 1, "w": 0},
+                {"n": 0, "e": 0, "s": 0, "w": 1}
+            ]
+        ], safe=False
+        )

--- a/build_week/settings.py
+++ b/build_week/settings.py
@@ -53,7 +53,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+        'build_week.users.backends.JSONWebTokenAuthentication',
     ),
     'EXCEPTION_HANDLER': 'build_week.exceptions.build_week_exception_handler',
     'NON_FIELD_ERRORS_KEY': 'error'

--- a/build_week/settings.py
+++ b/build_week/settings.py
@@ -43,7 +43,7 @@ INSTALLED_APPS = [
     'django_extensions',
     'rest_framework',
     'users',
-    'build_week.rooms'
+    'rooms'
 
 
 ]
@@ -53,7 +53,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'build_week.users.backends.JSONWebTokenAuthentication',
+        'users.backends.JWTAuthentication',
     ),
     'EXCEPTION_HANDLER': 'build_week.exceptions.build_week_exception_handler',
     'NON_FIELD_ERRORS_KEY': 'error'

--- a/build_week/urls.py
+++ b/build_week/urls.py
@@ -6,6 +6,6 @@ from rooms import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('auth/', include('users.urls', namespace='users')),
-    path('api/rooms/', views.all_rooms)
+    path('api/rooms/', views.RoomsView.as_view())
 
 ]

--- a/build_week/users/backends.py
+++ b/build_week/users/backends.py
@@ -24,13 +24,14 @@ class JWTAuthentication(authentication.BaseAuthentication):
         """
 
         request.user = None
+        print(f'request: {request}')
 
         # 'auth_header' should be an array with two elements:
         # 1) name of header ('Token')
         # 2) the JWT itself
         auth_header = authentication.get_authorization_header(request).split()
         auth_header_prefix = self.authentication_header_prefix.lower()
-
+        print(f'auth_header: {auth_header}, {type(auth_header)}')
         if not auth_header:
             return None
 

--- a/build_week/users/backends.py
+++ b/build_week/users/backends.py
@@ -1,0 +1,74 @@
+import jwt
+
+from django.conf import settings
+from rest_framework import authentication, exceptions
+
+from .models import User
+
+
+class JWTAuthentication(authentication.BaseAuthentication):
+    authentication_header_prefix = 'Token'
+
+    def authenticate(self, request):
+        """
+        This method called on every request regardless of whether
+        the endpoint requires authentication.
+
+        Two possible return cases:
+
+        1) 'None' - Do not wish to authenticate/know it will fail.
+
+        2) '(user, token)' - We return a user/token combo when authentication
+        is successful. If neither case is met, there's an error and don't return anything.
+        Instead raise an exception and let DRF handle it.
+        """
+
+        request.user = None
+
+        # 'auth_header' should be an array with two elements:
+        # 1) name of header ('Token')
+        # 2) the JWT itself
+        auth_header = authentication.get_authorization_header(request).split()
+        auth_header_prefix = self.authentication_header_prefix.lower()
+
+        if not auth_header:
+            return None
+
+        if len(auth_header) == 1:
+            # Invalid, no credentials provided. Don't attempt to authenticate
+            return None
+        elif len(auth_header) > 2:
+            # Invalid, Token string should not contain spaces. Don't authenticate.
+            return None
+
+        # decode prefix and token
+        prefix = auth_header[0].decode('utf-8')
+        token = auth_header[1].decode('utf-8')
+
+        if prefix.lower() != auth_header_prefix:
+            # Auth header not what we expected. Don't authenticate.
+            return None
+        return self._authenticate_credentials(request, token)
+
+    def _authenticate_credentials(self, request, token):
+        """
+        Try to authenticate the given credentials. If authentication is
+        successful, return the user and token. If not, throw and error.
+        """
+        try:
+            payload = jwt.decode(token, settings.SECRET_KEY)
+        except:
+            msg = "Invalid authentication. Could not decode token."
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            user = User.objects.get(pk=payload['id'])
+        except User.DoesNotExist:
+            msg = "No user matching this token was found."
+            raise exceptions.AuthenticationFailed(msg)
+
+        if not user.is_active:
+            msg = "This user has been deactivated."
+            raise exceptions.AuthenticationFailed(msg)
+
+        return (user, token)

--- a/build_week/users/backends.py
+++ b/build_week/users/backends.py
@@ -7,7 +7,6 @@ from .models import User
 
 
 class JWTAuthentication(authentication.BaseAuthentication):
-    authentication_header_prefix = 'Token'
 
     def authenticate(self, request):
         """
@@ -24,31 +23,24 @@ class JWTAuthentication(authentication.BaseAuthentication):
         """
 
         request.user = None
-        print(f'request: {request}')
 
         # 'auth_header' should be an array with two elements:
         # 1) name of header ('Token')
         # 2) the JWT itself
-        auth_header = authentication.get_authorization_header(request).split()
-        auth_header_prefix = self.authentication_header_prefix.lower()
-        print(f'auth_header: {auth_header}, {type(auth_header)}')
+        auth_header = authentication.get_authorization_header(
+            request).split()
         if not auth_header:
             return None
 
-        if len(auth_header) == 1:
+        if len(auth_header) == 0:
             # Invalid, no credentials provided. Don't attempt to authenticate
             return None
-        elif len(auth_header) > 2:
+        elif len(auth_header) > 1:
             # Invalid, Token string should not contain spaces. Don't authenticate.
             return None
 
-        # decode prefix and token
-        prefix = auth_header[0].decode('utf-8')
-        token = auth_header[1].decode('utf-8')
-
-        if prefix.lower() != auth_header_prefix:
-            # Auth header not what we expected. Don't authenticate.
-            return None
+        # decode token
+        token = auth_header[0].decode('utf-8')
         return self._authenticate_credentials(request, token)
 
     def _authenticate_credentials(self, request, token):


### PR DESCRIPTION
Base authentication settings changed to use custom JWTAuthentication class. Class grabs the request headers and validates the Authorization key's `token`, and only allows access to the specified routes if a valid token is found and decoded. This means that the pattern for the authenticated endpoints must follow a certain structure: they must be a view class extending the base APIView class, and have their `permission_classes` set to `[IsAuthenticated]` from the DRF.permissions library. Their methods must also follow the method naming conventions of `def get()`, `post`, etc