### PR TITLE
:bug: Removing pk field from expected input

### DIFF
--- a/build_week/users/serializers.py
+++ b/build_week/users/serializers.py
@@ -21,7 +21,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
         model = User
         # list all fields that could possible be included in a request
         # or response
-        fields = ['username', 'password', 'current_room', 'pk', 'token']
+        fields = ['username', 'password', 'current_room', 'token']
 
     def create(self, validated_data):
         # Use the 'create_user' method to create a new user


### PR DESCRIPTION
Former PR mistakenly expected a 'pk' field requirement on the user being registered. This PR fixes that issue and full local flow has been tested with registration, login, and restricted access to rooms/ and move/ endoints